### PR TITLE
fix: update repo URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
-ddev add-on get https://github.com/tyler36/ollama/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev add-on get https://github.com/tyler36/ddev-ollama/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/tyler36/ollama/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/tyler36/ollama/actions/workflows/tests.yml?query=branch%3Amain)
-[![last commit](https://img.shields.io/github/last-commit/tyler36/ollama)](https://github.com/tyler36/ollama/commits)
-[![release](https://img.shields.io/github/v/release/tyler36/ollama)](https://github.com/tyler36/ollama/releases/latest)
+[![tests](https://github.com/tyler36/ddev-ollama/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/tyler36/ddev-ollama/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-ollama)](https://github.com/tyler36/ddev-ollama/commits)
+[![release](https://img.shields.io/github/v/release/tyler36/ddev-ollama)](https://github.com/tyler36/ddev-ollama/releases/latest)
 
 # DDEV Ollama
 
@@ -14,7 +14,7 @@ This add-on integrates [Ollama](https://ollama.com/) into your [DDEV](https://dd
 ## Installation
 
 ```bash
-ddev add-on get tyler36/ollama
+ddev add-on get tyler36/ddev-ollama
 ddev restart
 ```
 
@@ -33,7 +33,7 @@ To change the Docker image:
 
 ```bash
 ddev dotenv set .ddev/.env.ollama --ollama-docker-image="ollama/ollama:latest"
-ddev add-on get tyler36/ollama
+ddev add-on get tyler36/ddev-ollama
 ddev restart
 ```
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -16,7 +16,7 @@ setup() {
   set -eu -o pipefail
 
   # Override this variable for your add-on:
-  export GITHUB_REPO=tyler36/ollama
+  export GITHUB_REPO=tyler36/ddev-ollama
 
   TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
   export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"


### PR DESCRIPTION
## The Issue

The repo was renamed but still included references to old name.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR updates references to the repository URL with the correct URL.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ollama/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
