### PR TITLE
doc: NVIDIA GPU Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,35 @@ Many Ollama-compatible packages recommend setting this directly in an `.env`:
 OLLAMA_BASE_URL=ollama:11434
 ```
 
+### NVIDIA GPU Support
+
+> [!Note]
+> NVIDIA GPU support is only available for Linux and WSL2.
+
+To allow the Ollama container to use your GPU,
+
+1. Install [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+2. Create `.ddev/docker-compose.ollama-gpu.yaml` and add the following:
+
+    ```yml
+    # .ddev/docker-compose.ollama-gpu.yaml
+    services:
+      ollama:
+        deploy:
+          resources:
+            reservations:
+              devices:
+                - driver: nvidia
+                  count: all
+                  capabilities: [gpu]
+    ```
+
+3. Restart DDEV to apply changes
+
+    ```shell
+    ddev restart
+    ```
+
 ## Credits
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36)**


### PR DESCRIPTION
## Issue

How can I use my GPU with the addon?

## Solution

This PR documents a process to add GPU support.
Currently, this method is not supported in MacOS. However, this industry is changing rapidily. PRs are welcome to address this.

## Test

1. Install addon.
2. Follow instructions to add GPU support.
3. Install model. Eg.

```shell
ddev ollama pull qwen3.5:4b
```

4.  Run model and confirm GPU memory is used.

```shell
$ ddev ollama run qwen3.5:4b
>>> tell me a joke about DDEV
Why don't developers ever finish their DDEV projects?
....
```

I tested on a Win10 system and checked  Video memory via Task Manager. Token speed was also significantly faster when enabling GPU support.
